### PR TITLE
disable zoom on keyboard double tap

### DIFF
--- a/index.css
+++ b/index.css
@@ -224,6 +224,7 @@ a {
   -webkit-user-select: none;
   -moz-user-select: none;
   font-size: 16px;
+  touch-action: manipulation;
 }
 
 .board {


### PR DESCRIPTION
This is a small fix to disable the option of zooming in when tapping the keyboard on mobile devices which is troublesome when typing fast, or deleting the letters